### PR TITLE
Add Robotic page and timeline entry

### DIFF
--- a/app/robotic/page.tsx
+++ b/app/robotic/page.tsx
@@ -1,0 +1,34 @@
+import React from 'react';
+
+export const metadata = {
+  title: 'Robotic',
+};
+
+export default function RoboticPage() {
+  return (
+    <main className="flex flex-col items-center justify-center min-h-screen p-8 gap-6 bg-background text-foreground">
+      <h1 className="text-4xl font-bold">Robotic</h1>
+      <p className="text-center max-w-xl">
+        This page showcases my robotics work in SPB. Explore the code repository and project board below.
+      </p>
+      <div className="flex gap-4">
+        <a
+          href="https://github.com/SwollEngineAF/lipan"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="px-4 py-2 rounded-md bg-blue-600 text-white hover:bg-blue-700"
+        >
+          GitHub Repo
+        </a>
+        <a
+          href="https://github.com/users/SwollEngineAF/projects/1/views/1"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="px-4 py-2 rounded-md bg-blue-600 text-white hover:bg-blue-700"
+        >
+          Project Board
+        </a>
+      </div>
+    </main>
+  );
+}

--- a/components/recentprojects.tsx
+++ b/components/recentprojects.tsx
@@ -5,6 +5,14 @@ import { Timeline } from "@/components/ui/timeline";
 export function RecentProjects() {
   const data = [
     {
+      title: "2025",
+      content: (
+        <div>
+          <a href="/robotic" className="text-blue-600 underline">Robotic</a>
+        </div>
+      ),
+    },
+    {
       title: "2023 - 2024",
       content: (
         <div>


### PR DESCRIPTION
## Summary
- create a new **Robotic** page to showcase SPB work with links to GitHub repo and project board
- link the new page from the timeline for 2025

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_684155fb8ad0832781c5f6dbfeb0c884